### PR TITLE
Abi: Choose word width of 32b for x86 target-triplets

### DIFF
--- a/src/plugins/projectexplorer/abi.cpp
+++ b/src/plugins/projectexplorer/abi.cpp
@@ -466,6 +466,7 @@ Abi Abi::abiFromTargetTriplet(const QString &triple)
         } else if (p == QLatin1String("i386") || p == QLatin1String("i486") || p == QLatin1String("i586")
                    || p == QLatin1String("i686") || p == QLatin1String("x86")) {
             arch = Abi::X86Architecture;
+            width = 32;
         } else if (p.startsWith(QLatin1String("arm"))) {
             arch = Abi::ArmArchitecture;
             width = 32;


### PR DESCRIPTION
Signed-off-by: Martin Kampas martin.kampas@jolla.com
(cherry picked from commit 822faedc65e1b28091272acf1e52cb95d261ab2a)
