### PR TITLE
Mer: Do not de-configure projects on target addition

### DIFF
--- a/src/plugins/mer/mersdk.cpp
+++ b/src/plugins/mer/mersdk.cpp
@@ -50,6 +50,12 @@ MerSdk::MerSdk(QObject *parent) : QObject(parent)
     , m_headless(false)
 {
     connect(&m_watcher, SIGNAL(fileChanged(QString)), this, SLOT(handleTargetsFileChanged(QString)));
+
+    // Fired from handleTargetsFileChanged(), used to prevent removing and
+    // re-adding all targets due to non atomic targets file change.
+    m_updateTargetsTimer.setInterval(1000);
+    m_updateTargetsTimer.setSingleShot(true);
+    connect(&m_updateTargetsTimer, SIGNAL(timeout()), this, SLOT(updateTargets()));
 }
 
 MerSdk::~MerSdk()
@@ -354,7 +360,7 @@ void MerSdk::updateTargets()
 void MerSdk::handleTargetsFileChanged(const QString &file)
 {
     QTC_ASSERT(file == sharedTargetsPath() + QLatin1String(Constants::MER_TARGETS_FILENAME), return);
-    updateTargets();
+    m_updateTargetsTimer.start();
 }
 
 QList<MerTarget> MerSdk::readTargets(const Utils::FileName &fileName)

--- a/src/plugins/mer/mersdk.h
+++ b/src/plugins/mer/mersdk.h
@@ -27,6 +27,7 @@
 #include <coreplugin/id.h>
 #include <QFileSystemWatcher>
 #include <QStringList>
+#include <QTimer>
 
 namespace ProjectExplorer {
 class Kit;
@@ -133,6 +134,7 @@ private:
     int m_timeout;
     QList<MerTarget> m_targets;
     QFileSystemWatcher m_watcher;
+    QTimer m_updateTargetsTimer;
     bool m_headless;
 
 friend class MerSdkManager;


### PR DESCRIPTION
The shared targets.xml file is not updated atomically and thus the
change is received as all targets removal in the first step with all
open projects de-configured as a result.

[qtc] Do not de-configure projects on target addition. Fixes MER#811

Signed-off-by: Martin Kampas martin.kampas@jolla.com
(cherry picked from commit 2570e2d635beb42f70ff905156d1e1289d06de18)
