### PR TITLE
[qtc] disable updateinfo plugin

### DIFF
--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -69,11 +69,11 @@ exists(../shared/qbs/qbs.pro)|!isEmpty(QBS_INSTALL_DIR): \
 
 isEmpty(IDE_PACKAGE_MODE) {
     SUBDIRS += \
-        helloworld \
-        updateinfo
-} else:!isEmpty(UPDATEINFO_ENABLE) {
-    SUBDIRS += \
-        updateinfo
+        helloworld # \
+        #updateinfo
+#} else:!isEmpty(UPDATEINFO_ENABLE) {
+#    SUBDIRS += \
+#        updateinfo
 }
 
 minQtVersion(5, 2, 0) {


### PR DESCRIPTION
Random crashes seem to be caused by the obsolete updateinfo
plugin.

https://bugreports.qt-project.org/browse/QTCREATORBUG-11262

This also disables the "updates available" pop up, which makes
noticing SDK updates more difficult.

Signed-off-by: Juha Kallioinen juha.kallioinen@jolla.com
