### PR TITLE
Use active project path for deployment

### DIFF
--- a/src/plugins/mer/merdeploysteps.cpp
+++ b/src/plugins/mer/merdeploysteps.cpp
@@ -116,6 +116,15 @@ bool MerProcessStep::init()
     ProcessParameters *pp = processParameters();
 
     Utils::Environment env = bc ? bc->environment() : Utils::Environment::systemEnvironment();
+
+    // By default, MER_SSH_PROJECT_PATH is set to the project explorer variable
+    // "%{CurrentProject:Path}". If multiple projects are open, "CurrentProject" may
+    // not be the project set as active (i.e. the project being deployed), leading
+    // to RPM build looking for files in the wrong project. Instead, MER_SSH_PROJECT_PATH
+    // needs to be set to the source directory of the active project. Note that this path
+    // is the same, whether or not shadow builds are enabled.
+    env.set(QLatin1String(Constants::MER_SSH_PROJECT_PATH), project()->projectDirectory());
+
     //TODO HACK
     if(!device.isNull())
         env.appendOrSet(QLatin1String(Constants::MER_SSH_DEVICE_NAME),device->displayName());


### PR DESCRIPTION
For deployment steps, the source path of the active project is now always used as the value of the `MER_SSH_PROJECT_PATH` environment variable instead of the expanded value of the project explorer variable "%{CurrentProject:Path}".

Note that when multiple projects are open, deploying a project via the _Build | Deploy Project "myproject"_ menu action causes a technically incorrect project path value (i.e. the path of the project that contains the directory or file that is currently highlighted in the project explorer view, __not__ the path of the project set as active) to be passed in `MER_SSH_PROJECT_PATH` for the `qmake` and `make` MerSSH commands.

For these two commands, the path set in `MER_SSH_PROJECT_PATH` has to exists but the value seems to be otherwise ignored.