### PR TITLE
Core: Fix FancyToolButton initial visibility

### DIFF
--- a/src/plugins/coreplugin/fancyactionbar.cpp
+++ b/src/plugins/coreplugin/fancyactionbar.cpp
@@ -321,6 +321,7 @@ void FancyActionBar::addProjectSelector(QAction *action)
     FancyToolButton* toolButton = new FancyToolButton(this);
     toolButton->setDefaultAction(action);
     connect(action, SIGNAL(changed()), toolButton, SLOT(actionChanged()));
+    toolButton->actionChanged();
     m_actionsLayout->insertWidget(0, toolButton);
 
 }
@@ -329,6 +330,7 @@ void FancyActionBar::insertAction(int index, QAction *action)
     FancyToolButton *toolButton = new FancyToolButton(this);
     toolButton->setDefaultAction(action);
     connect(action, SIGNAL(changed()), toolButton, SLOT(actionChanged()));
+    toolButton->actionChanged();
     m_actionsLayout->insertWidget(index, toolButton);
 }
 

--- a/src/plugins/coreplugin/fancyactionbar.h
+++ b/src/plugins/coreplugin/fancyactionbar.h
@@ -58,6 +58,7 @@ public:
     void setFader(float value) { m_fader = value; update(); }
 
 private slots:
+    friend class FancyActionBar;
     void actionChanged();
 };
 


### PR DESCRIPTION
This fixes the case when action is set not visible _before_ adding with
FancyActionBar::insertAction.

(cherry picked from commit 5b7d80c032cda37ac68134a6c81ee704a1a89693)