### PR TITLE
Mer: MerEmulatorDevice: only use std::bind when available

### DIFF
--- a/src/plugins/mer/meremulatordevice.cpp
+++ b/src/plugins/mer/meremulatordevice.cpp
@@ -185,14 +185,18 @@ MerEmulatorDevice::MerEmulatorDevice():
     , m_orientation(Qt::Vertical)
     , m_viewScaled(false)
 {
+#if __cplusplus >= 201103L
     m_virtualMachineChangedConnection =
         QObject::connect(m_connection.data(), &MerConnection::virtualMachineChanged,
                          std::bind(&MerEmulatorDevice::updateAvailableDeviceModels, this));
+#endif
 }
 
 MerEmulatorDevice::~MerEmulatorDevice()
 {
+#if __cplusplus >= 201103L
     QObject::disconnect(m_virtualMachineChangedConnection);
+#endif
 }
 
 ProjectExplorer::IDeviceWidget *MerEmulatorDevice::createWidget()
@@ -344,6 +348,9 @@ QSsh::SshConnectionParameters MerEmulatorDevice::sshParametersForUser(const QSsh
 
 QMap<QString, QSize> MerEmulatorDevice::availableDeviceModels() const
 {
+#if __cplusplus < 201103L
+    updateAvailableDeviceModels();
+#endif
     return m_availableDeviceModels;
 }
 

--- a/src/plugins/mer/meremulatordevice.h
+++ b/src/plugins/mer/meremulatordevice.h
@@ -94,7 +94,9 @@ private:
 
 private:
     QSharedPointer<MerConnection> m_connection; // all clones share the connection
+#if __cplusplus >= 201103L
     QMetaObject::Connection m_virtualMachineChangedConnection;
+#endif
     QString m_mac;
     QString m_subnet;
     QString m_sharedConfigPath;


### PR DESCRIPTION
MerEmulatorDevice is not a QObject, so std::bind was used to connect a
signal to updateAvailableDeviceModels() when needed.
MerEmulatorDevice::availableDeviceModels() is rarely called so let it
call updateAvailableDeviceModels() itself as a workaround.