### PR TITLE
Mini target selector: Make the kit area look less like a header

### DIFF
--- a/src/plugins/projectexplorer/miniprojecttargetselector.cpp
+++ b/src/plugins/projectexplorer/miniprojecttargetselector.cpp
@@ -553,6 +553,11 @@ KitAreaWidget::KitAreaWidget(QWidget *parent) : QWidget(parent),
 {
     m_layout->setMargin(3);
     setKit(0);
+
+    QPalette p;
+    p.setColor(QPalette::Window, QColor(70, 70, 70, 255));
+    setPalette(p);
+    setAutoFillBackground(true);
 }
 
 void KitAreaWidget::setKit(Kit *k)


### PR DESCRIPTION
With the light background it was not obvious this is an interactive
widget; it looked like a non-interactive header of the popup widget.