### PR TITLE
Mer: Start vboxmanage getextradata with QIODevice::Text

### DIFF
--- a/src/plugins/mer/mervirtualboxmanager.cpp
+++ b/src/plugins/mer/mervirtualboxmanager.cpp
@@ -287,7 +287,7 @@ QString MerVirtualBoxManager::getExtraData(const QString &vmName, const QString 
     arguments.append(vmName);
     arguments.append(key);
     QProcess process;
-    process.start(vBoxManagePath(), arguments);
+    process.start(vBoxManagePath(), arguments, QIODevice::ReadWrite | QIODevice::Text);
     if (!process.waitForFinished()) {
         qWarning() << "VBoxManage failed to getextradata";
         return QString();


### PR DESCRIPTION
Fixes reading emulator device modes where EOL <> LF