### PR TITLE
Help: Fix font in QtWebKitHelpView too small

### DIFF
--- a/src/plugins/help/qtwebkithelpviewer.cpp
+++ b/src/plugins/help/qtwebkithelpviewer.cpp
@@ -421,7 +421,7 @@ void QtWebKitHelpViewer::setViewerFont(const QFont &font)
 {
     QWebSettings *webSettings = m_webView->settings();
     webSettings->setFontFamily(QWebSettings::StandardFont, font.family());
-    webSettings->setFontSize(QWebSettings::DefaultFontSize, font.pointSize());
+    webSettings->setFontSize(QWebSettings::DefaultFontSize, QFontInfo(font).pixelSize());
 }
 
 void QtWebKitHelpViewer::scaleUp()


### PR DESCRIPTION
Most probably no one ever noticed this because Qt docs set font size
explicitly in their CSS
https://code.qt.io/cgit/qt/qtbase.git/tree/doc/global/template/style/offline.css#n2