### PR TITLE
Mer: Add QT_LOGGING_TO_CONSOLE=1 to environment

### DIFF
--- a/src/plugins/mer/merrunconfiguration.cpp
+++ b/src/plugins/mer/merrunconfiguration.cpp
@@ -112,7 +112,10 @@ Runnable MerRunConfiguration::runnable() const
 {
     auto r = RemoteLinuxRunConfiguration::runnable().as<StandardRunnable>();
     // required by qtbase not to direct logs to journald
+    // for Qt < 5.4
     r.environment.appendOrSet(QLatin1String("QT_NO_JOURNALD_LOG"), QLatin1String("1"));
+    // for Qt >= 5.4
+    r.environment.appendOrSet(QLatin1String("QT_LOGGING_TO_CONSOLE"), QLatin1String("1"));
 
     auto merAspect = extraAspect<MerRunConfigurationAspect>();
     if (merAspect->isQmlLiveEnabled()) {


### PR DESCRIPTION
With Qt 5.4 support for the deprecated QT_NO_JOURNALD_LOG and similar
variables was dropped. QT_LOGGING_TO_CONSOLE is to be used instead.