### PR TITLE
RemoteLinux: Quiet device process termination

### DIFF
--- a/src/plugins/remotelinux/linuxdeviceprocess.cpp
+++ b/src/plugins/remotelinux/linuxdeviceprocess.cpp
@@ -70,6 +70,7 @@ QString LinuxDeviceProcess::fullCommandLine(const StandardRunnable &runnable) co
         fullCommandLine.append(QLatin1Char(' ')).append(envString);
     if (!fullCommandLine.isEmpty())
         fullCommandLine += QLatin1Char(' ');
+    fullCommandLine.append(QLatin1String("exec "));
     fullCommandLine.append(quote(runnable.executable));
     if (!runnable.commandLineArguments.isEmpty()) {
         fullCommandLine.append(QLatin1Char(' '));


### PR DESCRIPTION
NOTE: Upstream has already applied this change in scope of
0bef624 (RemoteLinux: Allow killing
processes by ID)

This is to prevent message like this to appear in Application Output
pane when the process is terminated using the Stop button in Application
Output pane:

 bash: line 1:  3477 Terminated  ENV_VAR=val... /usr/bin/my_app
 Application finished with exit code 143.

With this change it would print just this:

 Process killed by signal

Which is not only shorter but also more informative (the application did
not handle the TERM signal).