### PR TITLE
Mer: Fixup Adapt to renamed Sailfish OS build engine and emulator

### DIFF
--- a/src/plugins/mer/mertarget.cpp
+++ b/src/plugins/mer/mertarget.cpp
@@ -302,7 +302,7 @@ bool MerTarget::createScript(const QString &targetPath, int scriptIndex) const
                 QLatin1Char('=') + targetName + QLatin1Char('\n');
         scriptContent += QLatin1String("set ") +
                 QLatin1String(MER_SSH_SDK_TOOLS) +
-                QLatin1String("=\"") + merDevToolsDir + QDir::separator() + targetName + QLatin1String("\"\n");
+                QLatin1Char('=') + merDevToolsDir + QDir::separator() + targetName + QLatin1Char('\n');
         scriptContent += QLatin1String("SetLocal DisableDelayedExpansion\n");
         scriptContent += QLatin1Char('"') +
                 QDir::toNativeSeparators(wrapperBinaryPath) + QLatin1String("\" ") +


### PR DESCRIPTION
This fixes commit cca7b44b3d919c7bf958ff868d6f47af0b702f92 (Mer: Adapt
to renamed Sailfish OS build engine and emulator)

Quoting a variable assignment with spaces is not needed in Windows CMD.
Moreover quotes become part of the assigned value.